### PR TITLE
📝 update port

### DIFF
--- a/slime-web/src/main/resources/config/application.yaml
+++ b/slime-web/src/main/resources/config/application.yaml
@@ -1,6 +1,6 @@
 # server
 server:
-  address: 127.0.0.1
+  address: 0.0.0.0
   port: 8086
   # tomcat
   tomcat:


### PR DESCRIPTION
使用docker启动镜像，内部如果监听127.0.0.1的话，容器内可以访问到但容器外访问不到，对于开箱即用不太友好